### PR TITLE
RC 1.0.0: Publish/Subscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ cargo add famcache
 ```
 
 ## Usage
-
 Here's a quick example of how to use famcache-rs:
+
+### Cache Operations
 
 ```rust
 use famcache::{Config, Famcache};
@@ -36,6 +37,32 @@ async fn main() -> Result<(), anyhow::Error> {
 
     println!("Connected to server: {:?}", val);
 
+    Ok(())
+}
+```
+
+### Messaging
+```rust
+use anyhow::Result;
+use famcache::{Config, Famcache};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut client = Famcache::new(Config::new("localhost", 3577));
+
+    client.connect().await?;
+
+    let mut subscription = client.messaging.subscribe("topic1").await?;
+
+    tokio::spawn(async move {
+        loop {
+            let message = subscription.recv().await.unwrap();
+            println!("Received message: {}", message);
+        }
+    })
+    .await?;
+
+    client.messaging.unsubscribe("topic1").await?;
     Ok(())
 }
 ```
@@ -77,6 +104,25 @@ Returns the value associated with the key or `None` if the key does not exist.
 Deletes a value from the cache.
 
 - `key`: The key to delete.
+
+#### `messaging.publish(&self, topic: &str, data: &str) -> Result<()>`
+
+Publishes a message to a topic.
+
+- `topic`: The topic to publish to.
+- `data`: The message data to publish.
+
+#### `messaging.subscribe(&self, topic: &str) -> Result<Receiver<String>>`
+
+Subscribes to a topic and returns a receiver for receiving messages.
+
+- `topic`: The topic to subscribe to.
+
+#### `messaging.unsubscribe(&self, topic: &str) -> Result<()>`
+
+Unsubscribes from a topic.
+
+- `topic`: The topic to unsubscribe from.
 
 ## Development
 

--- a/src/bin/cache_example.rs
+++ b/src/bin/cache_example.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use famcache::{Config, Famcache};
 
 #[tokio::main]
@@ -9,10 +11,7 @@ async fn main() -> Result<(), anyhow::Error> {
     client.set("test", "rust", None).await?;
     client.set("test1", "rust2", None).await?;
 
-    client.messaging.publish("hello", "payload").await?;
-
     let val = client.get("test").await?;
-
     println!("Connected to server: {:?}", val);
 
     Ok(())

--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -9,6 +9,8 @@ async fn main() -> Result<(), anyhow::Error> {
     client.set("test", "rust", None).await?;
     client.set("test1", "rust2", None).await?;
 
+    client.messaging.publish("hello", "payload").await?;
+
     let val = client.get("test").await?;
 
     println!("Connected to server: {:?}", val);

--- a/src/bin/messaging_example.rs
+++ b/src/bin/messaging_example.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use famcache::{Config, Famcache};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut client = Famcache::new(Config::new("localhost", 3577));
+
+    client.connect().await?;
+
+    let mut subscription = client.messaging.subscribe("topic1").await?;
+
+    tokio::spawn(async move {
+        loop {
+            let message = subscription.recv().await.unwrap();
+            println!("Received message: {}", message);
+        }
+    })
+    .await?;
+
+    client.messaging.unsubscribe("topic1").await?;
+    Ok(())
+}

--- a/src/famcache/client.rs
+++ b/src/famcache/client.rs
@@ -1,6 +1,6 @@
 use crate::{commands, query::holder::CacheQuery};
 
-use super::{resolver::QueueResolver, Config};
+use super::{messaging::Messaging, resolver::QueueResolver, Config};
 use anyhow::{Context, Result};
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
@@ -14,6 +14,8 @@ pub struct Famcache {
     socket: Arc<RwLock<Option<TcpStream>>>,
     queue: Arc<RwLock<HashMap<String, QueueResolver>>>,
     config: Config,
+
+    pub messaging: Messaging,
 }
 
 impl Famcache {
@@ -31,6 +33,7 @@ impl Famcache {
             socket: Arc::new(RwLock::new(None)),
             queue: Arc::new(RwLock::new(HashMap::new())),
             config,
+            messaging: Messaging::new(Arc::new(RwLock::new(None))),
         }
     }
 
@@ -145,6 +148,8 @@ impl Famcache {
 
         let mut socket_guard = self.socket.write().await;
         *socket_guard = Some(socket);
+
+        self.messaging = Messaging::new(self.socket.clone());
 
         self.listen();
 

--- a/src/famcache/messaging/client.rs
+++ b/src/famcache/messaging/client.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::{io::AsyncWriteExt, net::TcpStream, sync::RwLock};
+use uuid::Uuid;
+
+pub struct Messaging {
+    socket: Arc<RwLock<Option<TcpStream>>>,
+}
+
+impl Messaging {
+    /// Create a new instance of the client
+    pub(crate) fn new(socket: Arc<RwLock<Option<TcpStream>>>) -> Self {
+        Messaging { socket }
+    }
+
+    pub async fn publish(&self, topic: &str, message: &str) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+
+        self.socket
+            .write()
+            .await
+            .as_mut()
+            .expect("Socket is not initialized")
+            .write_all(format!("{} PUBLISH {} {}\n", id, topic, message).as_bytes())
+            .await
+            .with_context(|| "Failed to send message to server")
+    }
+}

--- a/src/famcache/messaging/client.rs
+++ b/src/famcache/messaging/client.rs
@@ -1,21 +1,62 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{Context, Result};
-use tokio::{io::AsyncWriteExt, net::TcpStream, sync::RwLock};
+use tokio::{
+    io::AsyncWriteExt,
+    net::TcpStream,
+    sync::{
+        mpsc::{self, Receiver},
+        RwLock,
+    },
+};
 use uuid::Uuid;
 
+use super::resolver::MessageResolver;
+
 pub struct Messaging {
+    subscription: Arc<RwLock<HashMap<String, Arc<MessageResolver>>>>,
     socket: Arc<RwLock<Option<TcpStream>>>,
 }
 
 impl Messaging {
+    pub(crate) fn is_messaging_event(msg: &str) -> bool {
+        msg.starts_with("MESSAGE")
+    }
+
+    // example: MESSAGE topic1 payload
+    pub(crate) fn parse_body(msg: &str) -> (&str, &str) {
+        let parts: Vec<&str> = msg.split(' ').collect();
+        (parts[1], parts[2])
+    }
+
+    pub(crate) fn new_resolver() -> (Arc<MessageResolver>, Receiver<String>) {
+        let (sender, receiver) = mpsc::channel(2);
+        (Arc::new(MessageResolver::new(sender)), receiver)
+    }
+
     /// Create a new instance of the client
     pub(crate) fn new(socket: Arc<RwLock<Option<TcpStream>>>) -> Self {
-        Messaging { socket }
+        Messaging {
+            socket,
+            subscription: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    fn gen_id(&self) -> String {
+        Uuid::new_v4().to_string()
+    }
+
+    pub(crate) async fn trigger(&self, topic: &str, message: &str) {
+        let subscription = self.subscription.read().await;
+        if let Some(resolver) = subscription.get(topic) {
+            resolver.resolve(message.to_string()).await;
+        } else {
+
+        }
     }
 
     pub async fn publish(&self, topic: &str, message: &str) -> Result<()> {
-        let id = Uuid::new_v4().to_string();
+        let id = self.gen_id();
 
         self.socket
             .write()
@@ -25,5 +66,47 @@ impl Messaging {
             .write_all(format!("{} PUBLISH {} {}\n", id, topic, message).as_bytes())
             .await
             .with_context(|| "Failed to send message to server")
+    }
+
+    pub async fn unsubscribe(&self, topic: &str) -> Result<()> {
+        let id = self.gen_id();
+
+        self.socket
+            .write()
+            .await
+            .as_mut()
+            .expect("Socket is not initialized")
+            .write_all(format!("{} UNSUBSCRIBE {}\n", id, topic).as_bytes())
+            .await
+            .with_context(|| "Failed to send message to server")?;
+
+        {
+            let mut subscription = self.subscription.write().await;
+            subscription.remove(topic);
+        }
+
+        Ok(())
+    }
+
+    pub async fn subscribe(
+        &self,
+        topic: &str,
+    ) -> Result<Receiver<String>> {
+        let id = self.gen_id();
+
+        self.socket
+            .write()
+            .await
+            .as_mut()
+            .expect("Socket is not initialized")
+            .write_all(format!("{} SUBSCRIBE {}\n", id, topic).as_bytes())
+            .await
+            .with_context(|| "Failed to send message to server")?;
+
+        let mut subscription = self.subscription.write().await;
+        let (resolver, receiver) = Messaging::new_resolver();
+        subscription.insert(topic.to_string(), resolver);
+
+        Ok(receiver)
     }
 }

--- a/src/famcache/messaging/mod.rs
+++ b/src/famcache/messaging/mod.rs
@@ -1,3 +1,4 @@
 mod client;
+mod resolver;
 
 pub use client::Messaging;

--- a/src/famcache/messaging/mod.rs
+++ b/src/famcache/messaging/mod.rs
@@ -1,0 +1,3 @@
+mod client;
+
+pub use client::Messaging;

--- a/src/famcache/messaging/resolver.rs
+++ b/src/famcache/messaging/resolver.rs
@@ -1,0 +1,18 @@
+use tokio::sync::mpsc::Sender;
+
+#[derive(Debug)]
+pub struct MessageResolver {
+    pub(crate) sender: Sender<String>,
+}
+
+impl MessageResolver {
+    pub fn new(sender: Sender<String>) -> MessageResolver {
+        MessageResolver {
+            sender,
+        }
+    }
+
+    pub async fn resolve(&self, result: String) {
+        let _ = self.sender.send(result).await;
+    }
+}

--- a/src/famcache/mod.rs
+++ b/src/famcache/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 mod config;
 mod resolver;
+mod messaging;
 
 pub use client::Famcache;
 pub use config::Config;


### PR DESCRIPTION
# Implement Publish/Subscribe Methods for Famcache Server

### Summary

This pull request implements the publish/subscribe functionality for the Famcache server by providing the following methods in the Messaging struct:

1. `client.messaging.publish(topic: &str, message: &str) -> Result<()>`
    * **Description**: Publishes a message to the specified topic.
    * **Details**: Generates a unique ID for the message and sends it to the server using the provided socket.
3. `client.messaging.subscribe(topic: &str, callback: impl Fn(&str) + Send + Sync + 'static) -> Result<Receiver<String>>`
    * **Description**: Subscribes to the specified topic and sets up a callback to handle incoming messages.
    * **Details**: Sends a subscription request to the server and stores the subscription in an internal map.
5. `client.messaging.unsubscribe(topic: &str) -> Result<()>`
    * **Description**: Unsubscribes from the specified topic.
    * **Details**: Sends an unsubscription request to the server and removes the subscription from the internal map.


These methods enable clients to publish messages to topics, subscribe to topics, and unsubscribe from topics, facilitating efficient message distribution and handling within the Famcache server.